### PR TITLE
Fix the margin after page break

### DIFF
--- a/site/src/assets/css/edit.css
+++ b/site/src/assets/css/edit.css
@@ -75,7 +75,6 @@
 
   .vue-smart-page-break {
     page-break-before: always;
-    margin-top: 0 !important;
     border: none;
   }
 }


### PR DESCRIPTION
Whenever a resume contains multiple pages, the "Top Margin" setting is only honored on the first page. After the page break, the content starts immediately at the top of the page. The following commit fixes this.