### PR TITLE
fix: produce a fully stand-alone HTML on export

### DIFF
--- a/site/src/components/edit/toolbar/File.vue
+++ b/site/src/components/edit/toolbar/File.vue
@@ -58,68 +58,137 @@ const exportMd = () => {
 
 const exportHtml = () => {
   const html = renderMarkdown(data.mdContent);
-  
-  // Generate dynamic CSS based on current styles
+
+  const fontEN = styles.fontEN.fontFamily || styles.fontEN.name;
+  const fontCJK = styles.fontCJK.fontFamily || styles.fontCJK.name;
+
+  const backboneCss = data.cssContent.replaceAll(
+    PREVIEW_SELECTOR,
+    ".resume"
+  );
+
+  const paper = styles.paper;
+  const paperW = PAPER[paper].w;
+
   const dynamicCss = `
-    /* Dynamic Styles */
-    body {
-      font-family: ${styles.fontEN.fontFamily || styles.fontEN.name}, ${styles.fontCJK.fontFamily || styles.fontCJK.name};
-      font-size: ${styles.fontSize}px;
-      background-color: white;
-      color: black;
-      margin: ${styles.marginV}px ${styles.marginH}px;
-    }
-    
-    :not(.resume-header-item) > a {
-      color: ${styles.themeColor};
-    }
-    
-    h1, h2, h3 {
-      color: ${styles.themeColor};
-    }
-    
-    h1, h2 {
-      border-bottom-color: ${styles.themeColor};
-    }
-    
-    p, li {
-      line-height: ${styles.lineHeight.toFixed(2)};
-    }
-    
-    h2, h3 {
-      line-height: ${(styles.lineHeight * 1.154).toFixed(2)};
-    }
-    
-    dl {
-      line-height: ${(styles.lineHeight * 1.038).toFixed(2)};
-    }
-    
-    h2 {
-      margin-top: ${styles.paragraphSpace}px;
-    }
-  `;
-  
-  // Combine backbone CSS with dynamic CSS
-  const fullCss = data.cssContent + dynamicCss;
-  
-  // Create complete HTML document
+
+.resume {
+  font-family: ${fontEN}, ${fontCJK}, sans-serif;
+  font-size: ${styles.fontSize}px;
+  padding: ${styles.marginV}px ${styles.marginH}px;
+  width: ${paperW}mm;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.resume :not(.resume-header-item) > a {
+  color: ${styles.themeColor};
+}
+
+.resume h1, .resume h2, .resume h3 {
+  color: ${styles.themeColor};
+  font-weight: bold;
+}
+
+.resume h1, .resume h2 {
+  border-bottom-color: ${styles.themeColor};
+}
+
+.resume p, .resume li {
+  line-height: ${styles.lineHeight.toFixed(2)};
+}
+
+.resume h2, .resume h3 {
+  line-height: ${(styles.lineHeight * 1.154).toFixed(2)};
+}
+
+.resume dl {
+  line-height: ${(styles.lineHeight * 1.038).toFixed(2)};
+}
+
+.resume h2 {
+  margin-top: ${styles.paragraphSpace}px;
+}
+`;
+
+  const printCss = `
+@media print {
+  @page {
+    size: ${paper};
+    margin: 0;
+  }
+  html, body {
+    margin: 0;
+    padding: 0;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .resume {
+    width: 100%;
+    margin: 0;
+    box-shadow: none;
+  }
+}
+`;
+
+  const screenCss = `
+@media screen {
+  html {
+    background: #f0f0f0;
+  }
+  body {
+    margin: 0;
+    padding: 20px 0;
+  }
+  .resume {
+    background: white;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.15);
+    margin: 0 auto;
+  }
+}
+`;
+
+  const isSystemFont = (name: string) =>
+    EN_FONTS.some((f) => (f.fontFamily || f.name) === name) ||
+    CJK_FONTS.some((f) => (f.fontFamily || f.name) === name);
+
+  let googleFontsLink = "";
+  const gFontFamilies: string[] = [];
+  if (!isSystemFont(fontEN)) gFontFamilies.push(fontEN);
+  if (!isSystemFont(fontCJK)) gFontFamilies.push(fontCJK);
+  if (gFontFamilies.length) {
+    const families = gFontFamilies
+      .map((f) => `family=${f.replace(/\s+/g, "+")}:wght@400;700`)
+      .join("&");
+    googleFontsLink = `<link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?${families}&display=swap">`;
+  }
+
   const htmlDocument = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${data.curResumeName}</title>
+  ${googleFontsLink}
+  <script src="https://code.iconify.design/3/3.1.1/iconify.min.js"><\/script>
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <style>
-${fullCss}
+${backboneCss}
+${dynamicCss}
+${screenCss}
+${printCss}
   </style>
 </head>
 <body>
-  <main id="vue-smart-pages-preview">
+  <article class="resume">
 ${html}
-  </main>
+  </article>
 </body>
 </html>`;
-  
+
   downloadFile(`${saveName.value}.html`, htmlDocument);
 };
 </script>


### PR DESCRIPTION
The existing HTML export generated a bare file missing styles, icons, and fonts, making it unusable outside the app.

Changes:
- CSS selectors adapted for stand-alone use
- Added Iconify CDN so inline icons render
- Added KaTeX CDN so math formulas display
- Added Google Fonts support when a non-system font is active
- Added print styles with proper page sizing for print-to-PDF
- Added screen styles for a clean paper-on-gray preview

The exported HTML file now opens in any browser and looks identical to the editor preview.