### PR TITLE
fix(ui): remove gray background and border-radius in print mode

### DIFF
--- a/site/src/assets/css/edit.css
+++ b/site/src/assets/css/edit.css
@@ -38,6 +38,14 @@
     margin: 0;
   }
 
+  body {
+    background-color: white !important;
+  }
+
+  body > *:not(#__nuxt) {
+    display: none !important;
+  }
+
   .edit-page {
     height: auto;
   }
@@ -59,7 +67,9 @@
   }
 
   .pane-container {
-    border: none;
+    border: none !important;
+    background: transparent !important;
+    border-radius: 0 !important;
   }
 
   .vue-zoom {


### PR DESCRIPTION
- Remove the default dark background color and rounded corners of the resume container in print mode.
- Add defensive hiding for floating windows injected by third-party browser extensions (e.g., clipper, translation tools).
- Ensure the exported PDF background remains pure white without extraneous rendering artifacts.