### PR TITLE
Bugfix: add page-break CSS for \newpage in HTML/DOCX export

### DIFF
--- a/site/src/composables/resumeExport.ts
+++ b/site/src/composables/resumeExport.ts
@@ -46,6 +46,7 @@ export const useResumeExport = () => {
           padding: ${styles.marginV}px ${styles.marginH}px;
         }
         @page { size: ${styles.paper}; margin: 0; }
+        .md-it-newpage { page-break-before: always; break-before: page; }
       }
     `;
 


### PR DESCRIPTION
The HTML/DOCX export path renders markdown directly without the JS-based pagination used by the live preview, so the `\newpage` marker had no CSS effect and was silently dropped when printing the exported HTML to PDF.